### PR TITLE
major release 4.0.0

### DIFF
--- a/__tests__/utilities.test.ts
+++ b/__tests__/utilities.test.ts
@@ -1,10 +1,9 @@
 import {
-  createFakeEvent,
+  eventNameValue,
   generateError,
   readValue,
   stringIsNotEmpty,
 } from '../src/utilities';
-import { eventNameValue } from '../src';
 
 describe('validation helpers', () => {
   describe('stringIsNotEmpty', () => {
@@ -58,7 +57,7 @@ describe('validation helpers', () => {
       };
       expect(willThrowError).toThrow(
         Error(
-          `"eventNameValue" cannot read object ${event} because it does not have a target property.`,
+          `"eventNameValue" cannot read event object because it does not have a target property.`,
         ),
       );
     });
@@ -69,7 +68,7 @@ describe('validation helpers', () => {
       };
       expect(willThrowError).toThrow(
         Error(
-          `"eventNameValue" cannot read object ${event} because it does not have a target property.`,
+          `"eventNameValue" cannot read event object because it does not have a target property.`,
         ),
       );
     });
@@ -84,31 +83,6 @@ describe('validation helpers', () => {
       const error = ({ name }: any) => `${name} is nifty`;
       const result = generateError({ name: 'bob ross' })(error);
       expect(result).toBe('bob ross is nifty');
-    });
-  });
-
-  describe('createFakeEvent', () => {
-    it('returns an event with a target property', () => {
-      const event = createFakeEvent('title', 'bob ross');
-      expect(event.target).toBeDefined();
-
-      const event2 = createFakeEvent('title');
-      expect(event2('bob ross').target).toBeDefined();
-    });
-    it('returns an event with a target property with a name property', () => {
-      const event = createFakeEvent('title', 'bob ross');
-      expect(event.target.name).toBe('title');
-
-      const event2 = createFakeEvent('title');
-      expect(event2('bob ross').target.name).toBe('title');
-    });
-    it('returns an event with a target property with a value property', () => {
-      const event = createFakeEvent('title', 'bob ross');
-      expect(event.target.value).toBe('bob ross');
-
-      const partial = createFakeEvent('title');
-      const event2 = partial('bob ross');
-      expect(event2.target.value).toBe('bob ross');
     });
   });
 });

--- a/examples/vanilla.ts
+++ b/examples/vanilla.ts
@@ -1,4 +1,8 @@
-import {ValidationObject, ValidationSchema, ValidationState} from '../src/types';
+import {
+  ValidationObject,
+  ValidationSchema,
+  ValidationState,
+} from '../src/types';
 import {
   calculateIsValid,
   createGetAllErrors,
@@ -7,14 +11,14 @@ import {
   createResetValidationState,
   createValidate,
   createValidateAll,
-  createValidateAllIfTrue,
-  createValidateIfTrue,
+  createValidateAllIfDirty,
+  createValidateIfDirty,
   createValidateOnBlur,
   createValidateOnChange,
   createValidationState,
   gatherValidationErrors,
 } from '../src';
-import {readValue} from '../src/utilities';
+import { readValue } from '../src/utilities';
 
 // Use whatever kind of statemanagement you like, or use something simple like this
 const useCache = (
@@ -51,13 +55,13 @@ export function Validation<S>(validationSchema: ValidationSchema<S>) {
     setValidationState,
   );
 
-  const validateAllIfTrue = createValidateAllIfTrue(
+  const validateAllIfDirty = createValidateAllIfDirty(
     validationSchema,
     getValidationState,
     setValidationState,
   );
 
-  const validateIfTrue = createValidateIfTrue(
+  const validateIfDirty = createValidateIfDirty(
     validationSchema,
     getValidationState,
     setValidationState,
@@ -88,8 +92,8 @@ export function Validation<S>(validationSchema: ValidationSchema<S>) {
     setValidationState,
     validate,
     validateAll,
-    validateAllIfTrue,
-    validateIfTrue,
+    validateAllIfDirty,
+    validateIfDirty,
     validateOnBlur,
     validateOnChange,
     validationErrors: [],

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,12 @@
-// --[ Validation Object Types ]------------------------------------------------
+// // --[ Validation Object Types ]------------------------------------------------
 export type GetAllErrors<S> = (property: keyof S) => string[]
 export type GetError<S> = (property: keyof S) => string
 export type GetFieldValid<S> = (property: keyof S) => boolean
 export type ResetValidationState = () => void
 export type Validate<S> = (property: keyof S, value: S) => boolean
 export type ValidateAll<S> = (value: S, keys?: Array<keyof S>) => boolean
-export type ValidateAllIfTrue<S> = (value: S, keys?: Array<keyof S>) => boolean
-export type ValidateIfTrue<S> = (property: keyof S, value: S) => boolean
+export type ValidateAllIfDirty<S> = (value: S, keys?: Array<keyof S>) => boolean
+export type ValidateIfDirty<S> = (property: keyof S, value: S) => boolean
 export type ValidateOnBlur<S> = (value: S) => (event: any) => any
 export type ValidateOnChange<S> = (
   onChange: (event: any) => any,
@@ -25,8 +25,8 @@ export interface ValidationObject<S> {
   setValidationState: SetValidationState
   validate: Validate<S>
   validateAll: ValidateAll<S>
-  validateAllIfTrue: ValidateAllIfTrue<S>
-  validateIfTrue: ValidateIfTrue<S>
+  validateAllIfDirty: ValidateAllIfDirty<S>
+  validateIfDirty: ValidateIfDirty<S>
   validateOnBlur: ValidateOnBlur<S>
   validateOnChange: ValidateOnChange<S>
   validationErrors: string[]
@@ -45,13 +45,12 @@ export interface ValidationSchema<S> {
 }
 
 export interface ValidationStateProperty {
-  isValid: boolean
+  dirty: boolean
   errors: string[]
+  isValid: boolean
 }
 
 export type ValidationState = {
   [key: string]: ValidationStateProperty
 }
 
-// TODO: probably just scrap this, doesn't feel valuable to expose
-export type EventName = {[key: string]: string | number | boolean}

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,19 +1,5 @@
 /**
- *  curry :: ((a, b, ...) -> c) -> a -> b -> ... -> c
- */
-export function curry(fn: (...args: any) => any) {
-  const arity = fn.length;
-
-  return function $curry(...args: any): any {
-    if (args.length < arity) {
-      return $curry.bind(null, ...args);
-    }
-    return fn.call(null, ...args);
-  };
-}
-
-/**
- *  @De-formed
+ *  @De-formed/base
  *  Internal utility function. Takes an argument and if that argument is a
  *  function then it will call it with no parameters, otherwise it will just
  *  return the argument.
@@ -23,7 +9,7 @@ export const readValue = <A>(value: A) => {
 };
 
 /**
- *  @De-formed
+ *  @De-formed/base
  *  Internal utility function.
  */
 export const stringIsNotEmpty = (str: string): boolean => {
@@ -31,7 +17,7 @@ export const stringIsNotEmpty = (str: string): boolean => {
 };
 
 /**
- * @De-Formed
+ * @De-Formed/base
  * Internal Utility. Function that takes either a string or a function stransforming a form state
  * to a string to generate an error for the validation state.
  */
@@ -42,7 +28,7 @@ export const generateError =
   };
 
 /**
- *  @De-formed
+ *  @De-formed/base
  *  Internal Utility. Takes an event and extracts either the target.value
  *  property (or the target.checked property if type is 'checkbox') and returns
  *  it as the value of a key of target.name.
@@ -78,51 +64,6 @@ export const eventNameValue = (
     }
   }
   throw new Error(
-    `"eventNameValue" cannot read object ${event} because it does not have a target property.`,
+    `"eventNameValue" cannot read event object because it does not have a target property.`,
   );
 };
-
-/**
- *  @De-formed
- *  Internal Utility. Curried function that takes a string and a value and
- *  returns a fake event object to integrate form components that do not emit
- *  event objects. If you need to customize the event type you will need to use
- *  your own event emitter. "Text" is used as the event type by default in leu
- *  of "undefined" or "custom" to avoid potential type conflicts.
- *
- *  @example
- *  input: ("selected", "I love validations")
- *  output: {
- *    target: {
- *      name: 'selected',
- *      type: 'text',
- *      value: 'I love validations'
- *    }
- *  }
- *
- *  input: "selected"
- *  output (value) => ({
- *    target: {
- *      name: 'selected',
- *      type: 'text',
- *      value,
- *    }
- *  })
- *
- *  [example usage]
- *  const genericOnChange = pipe(
- *    eventNameValue,
- *    merge(formState),
- *    setFormState
- *  )
- *
- *  const handleSelectChange = pipe(
- *    createFakeEvent('selected'),
- *    genericOnChange
- *  )
- */
-export const createFakeEvent = curry(
-  (name: string, value: string | number | boolean): any => ({
-    target: { name, value, type: 'text' },
-  }),
-);


### PR DESCRIPTION
Performance Improvements:
- reduced the amount of shallow copying on validation updates

Breaking Changes:
- added a dirty flag to the validation state
- `validateAllIfTrue` replaced with `validateAllIfDirty`
- `validateIfTrue` replaced with `validateIfDirty`
- removed createFakeEvent utility
- removed eventNameValue utility

fixed an unexpected behavior when non-mutually exclusive validations ran consecutively with validateIfTrue. validateIfdirty solved the issue, so while the names of the functions have changed for better expressivity,
  the behavior of the functions and their signatures are the same.